### PR TITLE
カードの詳細UIにコストとタイプを追加

### DIFF
--- a/Assets/Resources/Prefab/UICanvas.prefab
+++ b/Assets/Resources/Prefab/UICanvas.prefab
@@ -1,5 +1,262 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &380874448588481446
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9133947156096816134}
+  - component: {fileID: 4091576047218165904}
+  - component: {fileID: 5594928906535629988}
+  - component: {fileID: 8663355553164871526}
+  m_Layer: 5
+  m_Name: FusionButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9133947156096816134
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 380874448588481446}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 2053534368890822078}
+  m_Father: {fileID: 3672998158794698765}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -400, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4091576047218165904
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 380874448588481446}
+  m_CullTransparentMesh: 1
+--- !u!114 &5594928906535629988
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 380874448588481446}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.65002096, b: 0.23113209, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8663355553164871526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 380874448588481446}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5594928906535629988}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &796178982726338648
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8362558889612664046}
+  - component: {fileID: 3675535412945914379}
+  - component: {fileID: 7074424715818669515}
+  m_Layer: 5
+  m_Name: CostText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8362558889612664046
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 796178982726338648}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5234222406237892059}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3675535412945914379
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 796178982726338648}
+  m_CullTransparentMesh: 1
+--- !u!114 &7074424715818669515
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 796178982726338648}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: X
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 137e900dc28cc13489e81b762f780370, type: 2}
+  m_sharedMaterial: {fileID: -5817142611404812280, guid: 137e900dc28cc13489e81b762f780370, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 30
+  m_fontSizeBase: 30
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &889001433917427256
 GameObject:
   m_ObjectHideFlags: 0
@@ -144,8 +401,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1733959734897652170}
+  - component: {fileID: 1773629863085356678}
+  - component: {fileID: 4435213896645585718}
+  - component: {fileID: 7445512875533920685}
   m_Layer: 5
-  m_Name: ButtonArea
+  m_Name: ActArea
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -165,13 +425,148 @@ RectTransform:
   m_Children:
   - {fileID: 6575171697561618051}
   m_Father: {fileID: 8760939182097433953}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 50}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 300, y: -150.87}
+  m_SizeDelta: {x: 600, y: 60}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &1773629863085356678
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1138132772856141177}
+  m_CullTransparentMesh: 1
+--- !u!114 &4435213896645585718
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1138132772856141177}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.4198113, g: 0.6696, b: 1, a: 0.11372549}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7445512875533920685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1138132772856141177}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: 60
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &1391311337474892352
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5234222406237892059}
+  - component: {fileID: 4281714649620593094}
+  - component: {fileID: 415005867563928885}
+  m_Layer: 5
+  m_Name: Cost
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5234222406237892059
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1391311337474892352}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8362558889612664046}
+  m_Father: {fileID: 1477051658804000866}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 25, y: -35.870026}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4281714649620593094
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1391311337474892352}
+  m_CullTransparentMesh: 1
+--- !u!114 &415005867563928885
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1391311337474892352}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.17054713, g: 1, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1534197060887966801
 GameObject:
   m_ObjectHideFlags: 0
@@ -568,12 +963,12 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1477051658804000866}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 584, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 300, y: -35.87}
+  m_SizeDelta: {x: 600, y: 71.74}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1976118046391231730
 CanvasRenderer:
@@ -667,6 +1062,141 @@ MonoBehaviour:
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
   m_margin: {x: 50, y: 10, z: 0, w: 10}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2270108888374544583
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4232749847791296839}
+  - component: {fileID: 7730019556878218699}
+  - component: {fileID: 3862663316901927551}
+  m_Layer: 5
+  m_Name: CardTypeText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4232749847791296839
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2270108888374544583}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1477051658804000866}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 300, y: -86.11}
+  m_SizeDelta: {x: 600, y: 28.74}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7730019556878218699
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2270108888374544583}
+  m_CullTransparentMesh: 1
+--- !u!114 &3862663316901927551
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2270108888374544583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Type
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 137e900dc28cc13489e81b762f780370, type: 2}
+  m_sharedMaterial: {fileID: -5817142611404812280, guid: 137e900dc28cc13489e81b762f780370, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 20, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -1264,6 +1794,104 @@ MonoBehaviour:
   ownTurnButton: {fileID: 4630518295620371615}
   opponentTurnObject: {fileID: 7541518872668278171}
   turnEndButton: {fileID: 4254109902475219466}
+--- !u!1 &3875484953033737023
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3672998158794698765}
+  - component: {fileID: 8658955480798680974}
+  - component: {fileID: 2126768389939095030}
+  - component: {fileID: 7749388845176357481}
+  m_Layer: 5
+  m_Name: FusionArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3672998158794698765
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3875484953033737023}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9133947156096816134}
+  m_Father: {fileID: 8760939182097433953}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 300, y: -210.87}
+  m_SizeDelta: {x: 600, y: 60}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &8658955480798680974
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3875484953033737023}
+  m_CullTransparentMesh: 1
+--- !u!114 &2126768389939095030
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3875484953033737023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.4198113, g: 0.6696, b: 1, a: 0.11372549}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7749388845176357481
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3875484953033737023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: 60
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &4138201263280340534
 GameObject:
   m_ObjectHideFlags: 0
@@ -1309,6 +1937,141 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4138201263280340534}
   m_CullTransparentMesh: 1
+--- !u!1 &4604347614811064489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5739242931014022256}
+  - component: {fileID: 2799080176963382949}
+  - component: {fileID: 6764547036117184712}
+  m_Layer: 5
+  m_Name: CardDetailText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5739242931014022256
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4604347614811064489}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8760939182097433953}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 300, y: -132.185}
+  m_SizeDelta: {x: 600, y: 37.37}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2799080176963382949
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4604347614811064489}
+  m_CullTransparentMesh: 1
+--- !u!114 &6764547036117184712
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4604347614811064489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Detail
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 137e900dc28cc13489e81b762f780370, type: 2}
+  m_sharedMaterial: {fileID: -5817142611404812280, guid: 137e900dc28cc13489e81b762f780370, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 26
+  m_fontSizeBase: 26
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 20, y: 0, z: 20, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4630518295620371615
 GameObject:
   m_ObjectHideFlags: 0
@@ -1443,15 +2206,15 @@ GameObject:
   - component: {fileID: 1702427405890481838}
   - component: {fileID: 9144431152024717854}
   - component: {fileID: 5462615898567050049}
-  - component: {fileID: 4305150048271681121}
   - component: {fileID: 2146822487046546797}
+  - component: {fileID: 1442919831665436065}
   m_Layer: 5
   m_Name: CardDetailUI
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8760939182097433953
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1465,14 +2228,16 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1477051658804000866}
+  - {fileID: 5739242931014022256}
   - {fileID: 1733959734897652170}
+  - {fileID: 3672998158794698765}
   m_Father: {fileID: 3628020627496536146}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -615.9, y: 499.2}
-  m_SizeDelta: {x: 600, y: 0}
+  m_SizeDelta: {x: 600, y: 270.87}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &1702427405890481838
 CanvasRenderer:
@@ -1525,33 +2290,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
-    m_Left: 5
-    m_Right: 5
-    m_Top: 16
-    m_Bottom: 16
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
   m_ChildAlignment: 1
   m_Spacing: 0
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
+  m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
---- !u!114 &4305150048271681121
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4738403957340110155}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalFit: 0
-  m_VerticalFit: 2
 --- !u!114 &2146822487046546797
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1565,8 +2316,162 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cardNameText: {fileID: 9059175905353810074}
-  cardDetailText: {fileID: 153625605427411300}
-  rectTransform: {fileID: 8760939182097433953}
+  cardCostText: {fileID: 7074424715818669515}
+  cardDetailText: {fileID: 6764547036117184712}
+  cardTypeText: {fileID: 3862663316901927551}
+  actArea: {fileID: 1138132772856141177}
+  fusionArea: {fileID: 3875484953033737023}
+  actButton: {fileID: 9211909447196907524}
+  fusionButton: {fileID: 8663355553164871526}
+--- !u!114 &1442919831665436065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4738403957340110155}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
+--- !u!1 &4754879007092198924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2053534368890822078}
+  - component: {fileID: 8924324277791318524}
+  - component: {fileID: 2760544971855405724}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2053534368890822078
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4754879007092198924}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9133947156096816134}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8924324277791318524
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4754879007092198924}
+  m_CullTransparentMesh: 1
+--- !u!114 &2760544971855405724
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4754879007092198924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u878D\u5408"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 137e900dc28cc13489e81b762f780370, type: 2}
+  m_sharedMaterial: {fileID: -5817142611404812280, guid: 137e900dc28cc13489e81b762f780370, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4829657444473390249
 GameObject:
   m_ObjectHideFlags: 0
@@ -1652,10 +2557,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1477051658804000866}
-  - component: {fileID: 9185536730329371529}
-  - component: {fileID: 2116533300575099442}
+  - component: {fileID: 2966395879979163316}
+  - component: {fileID: 6128496110868539760}
+  - component: {fileID: 5234931144942454375}
   m_Layer: 5
-  m_Name: TextArea
+  m_Name: NameArea
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1673,17 +2579,26 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 5234222406237892059}
   - {fileID: 1610277047650861698}
-  - {fileID: 8457727914917120831}
+  - {fileID: 4232749847791296839}
   m_Father: {fileID: 8760939182097433953}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 300, y: -16}
-  m_SizeDelta: {x: 600, y: 0}
+  m_AnchoredPosition: {x: 300, y: 0}
+  m_SizeDelta: {x: 600, y: 113.5}
   m_Pivot: {x: 0.5, y: 1}
---- !u!114 &9185536730329371529
+--- !u!222 &2966395879979163316
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5203993142581689150}
+  m_CullTransparentMesh: 1
+--- !u!114 &6128496110868539760
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1692,24 +2607,28 @@ MonoBehaviour:
   m_GameObject: {fileID: 5203993142581689150}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 16
-    m_Right: 0
-    m_Top: 16
-    m_Bottom: 0
-  m_ChildAlignment: 0
-  m_Spacing: 0
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 1
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
---- !u!114 &2116533300575099442
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.4198113, g: 0.6696, b: 1, a: 0.11372549}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5234931144942454375
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1718,11 +2637,17 @@ MonoBehaviour:
   m_GameObject: {fileID: 5203993142581689150}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_HorizontalFit: 0
-  m_VerticalFit: 2
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: 113.5
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &5315863449352705554
 GameObject:
   m_ObjectHideFlags: 0
@@ -1825,141 +2750,6 @@ MonoBehaviour:
   m_fontStyle: 0
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &5466281744689590472
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8457727914917120831}
-  - component: {fileID: 7885495002814591032}
-  - component: {fileID: 153625605427411300}
-  m_Layer: 5
-  m_Name: CardDetailText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8457727914917120831
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5466281744689590472}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1477051658804000866}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 584, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &7885495002814591032
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5466281744689590472}
-  m_CullTransparentMesh: 1
---- !u!114 &153625605427411300
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5466281744689590472}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Detail
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 137e900dc28cc13489e81b762f780370, type: 2}
-  m_sharedMaterial: {fileID: -5817142611404812280, guid: 137e900dc28cc13489e81b762f780370, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -2189,7 +2979,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.65002096, b: 0.23113209, a: 1}
+  m_Color: {r: 1, g: 0.64230365, b: 0.21226418, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/Scripts/Common/GameEnum.cs
+++ b/Assets/Scripts/Common/GameEnum.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using static CardObject;
 
 public class GameEnum
 {
@@ -54,6 +55,7 @@ public class GameEnum
     public enum CardTypeDetail
     {
         INVALID = -1,
+        NONE,
         OFFICER,    // 兵士
         LUMINOUS,   // ルミナス
         LEVIN,      // レヴィオン
@@ -79,6 +81,42 @@ public class GameEnum
         CONDEMNED,  // 八獄
         ALL,        // すべて
         ACADEMIC,   // 学園
+    }
+
+    static readonly Dictionary<CardTypeDetail, string> map =
+    new Dictionary<CardTypeDetail, string>
+    {
+        { CardTypeDetail.NONE, "" },
+        { CardTypeDetail.OFFICER, "兵士" },
+        { CardTypeDetail.LUMINOUS, "ルミナス" },
+        { CardTypeDetail.LEVIN, "レヴィオン" },
+        { CardTypeDetail.PIXIE, "妖精" },
+        { CardTypeDetail.DEPARTED, "死者" },
+        { CardTypeDetail.EARTH_SIGIL, "土の印" },
+        { CardTypeDetail.MYSTERIA, "マナリア" },
+        { CardTypeDetail.GOLEM, "ゴーレム" },
+        { CardTypeDetail.SHIKIGAMI, "式神" },
+        { CardTypeDetail.ARTIFACT, "アーティファクト" },
+        { CardTypeDetail.PUPPETRY, "人形" },
+        { CardTypeDetail.MARINE, "海洋" },
+        { CardTypeDetail.LOOT, "財宝" },
+        { CardTypeDetail.ENCROACHER, "アサイラント" },
+        { CardTypeDetail.ANATHEMA, "アナテマ" },
+        { CardTypeDetail.COMMANDER, "指揮官" },
+        { CardTypeDetail.MACHINA, "機械" },
+        { CardTypeDetail.NATURA, "自然" },
+        { CardTypeDetail.FESTIVE, "宴楽" },
+        { CardTypeDetail.HEROIC, "ヒーロー" },
+        { CardTypeDetail.CHESS, "チェス" },
+        { CardTypeDetail.ARMED, "武装" },
+        { CardTypeDetail.CONDEMNED, "八獄" },
+        { CardTypeDetail.ALL, "すべて" },
+        { CardTypeDetail.ACADEMIC, "学園" },
+    };
+
+    public static string ToText(CardTypeDetail state)
+    {
+        return map.TryGetValue(state, out var text) ? text : "";
     }
 
     public enum BGM

--- a/Assets/Scripts/MainGame/Battle/BattleManager.cs
+++ b/Assets/Scripts/MainGame/Battle/BattleManager.cs
@@ -343,6 +343,7 @@ public class BattleManager : SystemObject
     public async UniTask EndTurn()
     {
         if (!UIManager.instance.IsCompleteAllSequence()) return;
+        UIManager.instance.EndTurn();
         // 自分の手札をプレイ不能にする
         bool isOwn = IsOwnTurn();
         field.OnEndTurn(isOwn);

--- a/Assets/Scripts/MainGame/Card/Ability/ActiveAbility/Condition/BaseCondition.cs
+++ b/Assets/Scripts/MainGame/Card/Ability/ActiveAbility/Condition/BaseCondition.cs
@@ -4,5 +4,5 @@ using UnityEngine;
 
 public abstract class BaseCondition
 {
-    public abstract bool IsAchievement();
+    public abstract bool IsConditionClear();
 }

--- a/Assets/Scripts/MainGame/Card/Ability/ActiveAbility/Target.meta
+++ b/Assets/Scripts/MainGame/Card/Ability/ActiveAbility/Target.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 6e5d67c07919f9f4597a0dc344de843e
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/MainGame/Card/Ability/ActiveAbility/Target/BaseTarget.cs
+++ b/Assets/Scripts/MainGame/Card/Ability/ActiveAbility/Target/BaseTarget.cs
@@ -1,8 +1,0 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
-public class BaseTarget
-{
-    
-}

--- a/Assets/Scripts/MainGame/Card/Ability/BaseCardAbility.cs
+++ b/Assets/Scripts/MainGame/Card/Ability/BaseCardAbility.cs
@@ -7,6 +7,18 @@ public abstract class BaseCardAbility
     public CardData sourceData;
     public List<KeywordAbilityInstance> keywordAbilities = new List<KeywordAbilityInstance>();
     public List<ActiveAbility> activeAbilities = new List<ActiveAbility>();
+    public Target[] selectTarget = new Target[(int)TargetTiming.Max];
+
+    public enum TargetTiming
+    {
+        Fanfare = 0,
+        Enhance,
+        Evolve,
+        SuperEvolve,
+        Engage,
+        Fuse,
+        Max
+    }
 
     protected BattleManager.Player GetPlayer(bool isOwn)
     {
@@ -50,7 +62,10 @@ public abstract class BaseCardAbility
     // 引いたとき
     public virtual void Draw(bool isOwn) {  }
     // アクト
-    public virtual void Engage(bool isOwn) { }
+    public virtual void Engage(bool isOwn)
+    {
+        sourceData.OnAct();
+    }
     // スペルブースト
     public virtual void SpellBoost(bool isOwn) { }
 }

--- a/Assets/Scripts/MainGame/Card/Ability/CardActionExecutor.cs
+++ b/Assets/Scripts/MainGame/Card/Ability/CardActionExecutor.cs
@@ -1,0 +1,30 @@
+using Cysharp.Threading.Tasks;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CardActionExecutor
+{
+    //public static async UniTask<bool> TryActAsync(CardData card, bool isOwn)
+    //{
+    //    var ability = card.ability;
+
+    //    // ターゲット選択が必要ないならスルー
+    //    IReadOnlyList<CardObject> targets = null;
+    //    if (targetDef != null && targetDef.isSelect)
+    //    {
+    //        var candidates = TargetSearcher.Search(targetDef, isOwn);
+
+    //        targets = await UIManager.instance.SelectTargetAsync(
+    //            candidates,
+    //            targetDef.count
+    //        );
+    //    }
+
+    //    // ここから確定
+    //    card.ConsumeAct();
+    //    ability.Engage(isOwn, targets);
+
+    //    return true;
+    //}
+}

--- a/Assets/Scripts/MainGame/Card/Ability/CardActionExecutor.cs.meta
+++ b/Assets/Scripts/MainGame/Card/Ability/CardActionExecutor.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cfdc86e7b9a638540be8d937dbb22bf9
+guid: c0eec544fea6b8945b017825bdce3acb
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/MainGame/Card/Ability/Target.cs
+++ b/Assets/Scripts/MainGame/Card/Ability/Target.cs
@@ -54,8 +54,6 @@ public class Target
     public TargetZone targetZone;
     public TargetCondition condition;
     public int count;
-    public bool isRandom;
-    public bool isSelect;
 
     public Target()
     {
@@ -63,18 +61,13 @@ public class Target
         targetZone = TargetZone.Field;
         condition = TargetCondition.Any;
         count = 1;
-        isRandom = false;
-        isSelect = true;
     }
 
-    public Target(TargetSide setSide, TargetZone setZone, TargetCondition setCondition, 
-        bool setRandom, bool setSelect, int setCount = 0)
+    public Target(TargetSide setSide, TargetZone setZone, TargetCondition setCondition, int setCount = 0)
     {
         targetSide = setSide;
         targetZone = setZone;
         condition = setCondition;
-        isRandom = setRandom;
-        isSelect = setSelect;
         count = setCount;
     }
 }

--- a/Assets/Scripts/MainGame/Card/BaseFieldObject.cs
+++ b/Assets/Scripts/MainGame/Card/BaseFieldObject.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -6,14 +7,32 @@ public class BaseFieldObject : MonoBehaviour
 {
     public bool isLocal { get; private set; } = false;
     public bool isSelectable { get; private set; } = false;
+    public event Action<BaseFieldObject> OnClick;
 
     public void SetIsLocal(bool setlocal)
     {
         isLocal = setlocal;
     }
 
-    public void SetIsSelectable(bool setSelectable)
+    /// <summary>
+    /// ‘I‘ğ‚Ì‰Â”Ûİ’è
+    /// </summary>
+    /// <param name="enable"></param>
+    public void EnableSelectable(bool enable)
     {
-        isSelectable = setSelectable;
+        isSelectable = enable;
+    }
+
+    /// <summary>
+    /// ‘I‘ğ‚³‚ê‚½‚Æ‚«
+    /// </summary>
+    public void SetSelected(bool select)
+    {
+        // Œ©‚½–Ú‚Ì•ÏX
+    }
+
+    public void OnPointerClick()
+    {
+        OnClick?.Invoke(this);
     }
 }

--- a/Assets/Scripts/MainGame/Card/CardData.cs
+++ b/Assets/Scripts/MainGame/Card/CardData.cs
@@ -49,7 +49,9 @@ public class CardData : BaseComponent
     // プレイ可能かどうか
     public bool canPlay { get; private set; }
     // アクト可能かどうか
-    public bool canAct { get; private set; }
+    public bool canAct { get; private set; } = true;
+    // 融合可能かどうか
+    public bool canFusion { get; private set; } = true;
     // カードの種類
     public CardType type { get; private set; }
     // 持っているカードタイプ
@@ -84,7 +86,7 @@ public class CardData : BaseComponent
         GetObject = action;
     }
 
-    public CardData(int setID, LeaderClass setClass, CardRarity setRarity, CardType setType, string setName, int setCost, int setAttack, int setDefence, bool setToken)
+    public CardData(int setID, LeaderClass setClass, CardRarity setRarity, CardType setType, string setName, int setCost, int setAttack, int setDefence, bool setToken, int[] setTrait)
     {
         id = setID;
         leaderClass = setClass;
@@ -95,6 +97,7 @@ public class CardData : BaseComponent
         defaultCost = setCost;
         status = new FollowerStatus(setAttack, setDefence);
         isToken = setToken;
+        SetTrait(setTrait);
 
         Init();
     }
@@ -105,6 +108,15 @@ public class CardData : BaseComponent
         ability = AbilityFactory.GetAbility(id);
         if (ability == null) return;
         ability.Initialize(this);
+    }
+
+    private void SetTrait(int[] setTrait)
+    {
+        for (int i = 0, max = setTrait.Length; i < max; i++)
+        {
+            CardTypeDetail trait = (CardTypeDetail)setTrait[i];
+            AddTypeDetail(trait);
+        }
     }
 
     public void OnPlay(bool isOwn, bool isEnhance)
@@ -119,6 +131,8 @@ public class CardData : BaseComponent
     public void OnStartTurn()
     {
         remainAttackCount = maxAttackCount;
+        canAct = true;
+        canFusion = true;
         SetAttackPermission(AttackPermission.CanAttackLeader);
         GetObject().SetAttackPermissionLook();
     }
@@ -134,6 +148,16 @@ public class CardData : BaseComponent
     {
         remainAttackCount = 0;
         GetObject().SetAttackPermissionLook();
+    }
+
+    public void OnAct()
+    {
+        canAct = false;
+    }
+
+    public void OnFusion()
+    {
+        canFusion = false;
     }
 
     public void SetType(CardType setType)

--- a/Assets/Scripts/MainGame/Card/CardObject.cs
+++ b/Assets/Scripts/MainGame/Card/CardObject.cs
@@ -66,6 +66,11 @@ public class CardObject : BaseFieldObject
 
     private void OnMouseDown()
     {
+        // 自分のカードもしくは場のカードをクリックした場合はUI表示
+        if (isLocal || currentState == CardState.FIELD)
+        {
+            UIManager.instance.SetCardDetailUI(this);
+        }
         if (!isLocal) return;
         switch (currentState)
         {
@@ -693,6 +698,8 @@ public class CardObject : BaseFieldObject
     /// </summary>
     public void SetAttackPermissionLook()
     {
+        // フォロワー以外は無視
+        if (cardData.type != CardType.FOLLOWER) return;
         // 現状はマテリアルで見た目変更
         CardLook fieldLook = cardObject[(int)CardState.FIELD].GetComponent<CardLook>();
         CardData.AttackPermission currentAttackPermission = cardData.GetAttackPermission();

--- a/Assets/Scripts/MainGame/Card/Cards/Basic/Neutral/CardAbility_3.cs
+++ b/Assets/Scripts/MainGame/Card/Cards/Basic/Neutral/CardAbility_3.cs
@@ -9,13 +9,16 @@ public class CardAbility_3 : BaseCardAbility
     {
         sourceData = setCard;
         keywordAbilities.Add(new KeywordAbilityInstance(GameEnum.KeywordAbility.Engage, null, ENGAGE_COST));
+        TargetCondition condition = TargetCondition.Any;
+        condition.type.Add(GameEnum.CardType.FOLLOWER);
+        selectTarget[(int)TargetTiming.Engage] = new Target(Target.TargetSide.Opponent, Target.TargetZone.Field, condition, 1);
     }
 
     public override void Engage(bool isOwn)
     {
         // これを破壊
         DestroyEffect destroyEffect = new DestroyEffect(null);
-        destroyEffect.ExecuteEffect();
+        destroyEffect.ExecuteEffect(sourceData);
         // 相手の場のをフォロワーを1体選ぶ。守護を失う 
         var targetCard = BattleManager.instance.field.GetRandomCard((card) => 
         {

--- a/Assets/Scripts/MainGame/UI/CardDetailUI.cs
+++ b/Assets/Scripts/MainGame/UI/CardDetailUI.cs
@@ -4,28 +4,34 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using static GameEnum;
 
 public class CardDetailUI : MonoBehaviour
 {
     [SerializeField]
     private TextMeshProUGUI cardNameText = null;
     [SerializeField]
+    private TextMeshProUGUI cardCostText = null;
+    [SerializeField]
     private TextMeshProUGUI cardDetailText = null;
     [SerializeField]
-    private RectTransform rectTransform = null;
+    private TextMeshProUGUI cardTypeText = null;
+    [SerializeField]
+    private GameObject actArea = null;
+    [SerializeField]
+    private GameObject fusionArea = null;
     [SerializeField]
     private Button actButton = null;
     [SerializeField]
     private Button fusionButton = null;
 
-    public void EnableUI(bool enable, string name = "", string detail = "", Action setActAction = null, Action setFusionAction = null)
+    public void EnableUI(bool enable, CardData card, Action setActAction = null, Action setFusionAction = null, bool isOwnTurn = false)
     {
         gameObject.SetActive(enable);
         if (enable)
         {
-            SetCardText(name, detail);
-            SetButton(setActAction, setFusionAction);
-            LayoutRebuilder.ForceRebuildLayoutImmediate(rectTransform);
+            SetCardText(card.name, card.defaultCost, card.text, card.typeDetail);
+            SetButton(setActAction, setFusionAction, isOwnTurn, card.canAct, card.canFusion);
         }
         else
         {
@@ -34,31 +40,52 @@ public class CardDetailUI : MonoBehaviour
         }
     }
 
-    private void SetCardText(string name, string detail)
+    public void EnableUI(bool enable, string name = "", string detail = "", int cost = -1, List<CardTypeDetail> type = null)
     {
-        cardNameText.text = name;
-        cardDetailText.text = detail;
+        gameObject.SetActive(enable);
+        if (enable)
+        {
+            SetCardText(name, cost, detail, type);
+        }
     }
 
-    private void SetButton(Action setActAction, Action setFusionAction)
+    private void SetCardText(string name,int cost, string detail, List<CardTypeDetail> type)
+    {
+        cardNameText.text = name;
+        cardCostText.text = cost.ToString();
+        cardDetailText.text = detail;
+        string typeText = "";
+        if (type != null)
+        {
+            for (int i = 0, max = type.Count; i < max; i++)
+            {
+                typeText += ToText(type[i]);
+            }
+        }
+        cardTypeText.text = typeText;
+    }
+
+    private void SetButton(Action setActAction, Action setFusionAction, bool isOwn, bool canAct, bool canFusion)
     {
         if (setActAction == null)
         {
-            actButton.gameObject.SetActive(false);
+            actArea.gameObject.SetActive(false);
         }
         else
         {
-            actButton.gameObject.SetActive(true);
+            actArea.gameObject.SetActive(true);
             actButton.onClick.AddListener(() => setActAction());
+            actButton.interactable = isOwn && canAct;
         }
         if (setFusionAction == null)
         {
-            fusionButton.gameObject.SetActive(false);
+            fusionArea.gameObject.SetActive(false);
         }
         else
         {
-            fusionButton.gameObject.SetActive(true);
+            fusionArea.gameObject.SetActive(true);
             fusionButton.onClick.AddListener(() => setFusionAction());
+            fusionButton.interactable = isOwn && canFusion;
         }
     }
 }

--- a/Assets/Scripts/MainGame/UI/UIManager.cs
+++ b/Assets/Scripts/MainGame/UI/UIManager.cs
@@ -3,11 +3,11 @@ using DG.Tweening;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using UnityEditor.VersionControl;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using static CardObject;
 using static CommonModule;
+using static UnityEngine.GraphicsBuffer;
 
 // UIを管理するマネージャー
 
@@ -108,7 +108,7 @@ public class UIManager : SystemObject
         // UIシーケンス処理
         UISequence();
 
-        CardClick();
+        CheckClick();
     }
 
     public async UniTask Message(string message, float sec)
@@ -132,36 +132,84 @@ public class UIManager : SystemObject
         }
     }
 
-    private void CardClick()
+    public void SetCardDetailUI(CardObject cardObject)
+    {
+        CardData cardData = cardObject.cardData;
+        // アクトを持っていて、場にあるならボタンを登録
+        Action actAction = null;
+        if (cardData.HaveKeyword(GameEnum.KeywordAbility.Engage) && 
+            cardObject.currentState == CardState.FIELD)
+        {
+            actAction = () =>
+            {
+                cardData.ability.Engage(cardObject.isLocal);
+                cardDetailUI.EnableUI(false);
+            };
+        }
+        // 融合を持っていて、手札にあるなら、ボタンを登録
+        Action fusionAction = null;
+        if (cardData.HaveKeyword(GameEnum.KeywordAbility.Fuse) &&
+            cardObject.currentState == CardState.HAND)
+        {
+            fusionAction = () =>
+            {
+                cardData.ability.Fuse(cardObject.isLocal);
+                cardDetailUI.EnableUI(false);
+            };
+        }
+        bool isOwnTurn = BattleManager.instance.IsOwnTurn();
+        cardDetailUI.EnableUI(true, cardData, actAction, fusionAction, isOwnTurn);
+    }
+
+    /// <summary>
+    /// カード以外のクリックを検知
+    /// </summary>
+    private void CheckClick()
     {
         if (!Input.GetMouseButtonDown(0)) return;
 
+        // UIがクリックされているならスキップ
+        if (IsClickDetailUI()) return;
+
         BaseFieldObject target = GetFieldObject(Input.mousePosition);
-        if (target != null && target as CardObject)
+        switch (state)
         {
-            CardObject card = target as CardObject;
-            // 相手の手札はクリックできない
-            if (!card.isLocal && card.currentState == CardState.HAND) return;
+            case UIState.DEFAULT:
+                ClickDefaultState(target);
+                break;
+            case UIState.SELECT:
+                ClickSelectState(target);
+                break;
+            default: break;
+        }
+    }
 
-            CardData cardData = card.cardData;
-            // アクトを持っていて、場にあるならボタンを登録
-            Action actAction = null;
-            if (cardData.HaveKeyword(GameEnum.KeywordAbility.Engage) && 
-                card.currentState == CardState.FIELD)
-            {
-                cardData.ability.Engage(card.isLocal);
-            }
-            // 融合を持っていて、手札にあるなら、ボタンを登録
-            Action fusionAction = null;
-            if (cardData.HaveKeyword(GameEnum.KeywordAbility.Engage) &&
-                card.currentState == CardState.HAND)
-            {
-
-            }
-            cardDetailUI.EnableUI(true, cardData.name, cardData.text, actAction, fusionAction);
+    private void ClickDefaultState(BaseFieldObject clickObject)
+    {
+        CardObject cardObject = clickObject as CardObject;
+        // カードオブジェクトでないなら詳細画面を閉じる
+        if (clickObject == null || cardObject == null)
+        {
+            cardDetailUI.EnableUI(false);
             return;
         }
+        // 相手の手札は詳細画面を出さない
+        if (clickObject.isLocal || cardObject.currentState == CardState.FIELD) return;
         cardDetailUI.EnableUI(false);
+    }
+
+    private void ClickSelectState(BaseFieldObject clickObject)
+    {
+        // オブジェクト以外がクリックされたらキャンセル処理へ
+        if (clickObject == null)
+        {
+            CompleteSelection(false);
+        }
+        // オブジェクトがクリックされていたら選択処理へ
+        else
+        {
+            clickObject.OnPointerClick();
+        }
     }
 
     public BaseFieldObject GetFieldObject(Vector2 screenPos)
@@ -176,6 +224,30 @@ public class UIManager : SystemObject
         if (hitObject == null) return null;
         BaseFieldObject target = hitObject.GetComponent<BaseFieldObject>();
         return target;
+    }
+
+    private bool IsClickDetailUI()
+    {
+        if (EventSystem.current == null) return false;
+
+        PointerEventData eventData = new PointerEventData(EventSystem.current)
+        {
+            position = Input.mousePosition
+        };
+
+        List<RaycastResult> results = new List<RaycastResult>();
+        EventSystem.current.RaycastAll(eventData, results);
+
+        foreach (var result in results)
+        {
+            // CardDetailUI 自身、または子オブジェクトなら true
+            if (result.gameObject.GetComponentInParent<CardDetailUI>() == cardDetailUI)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private bool IsCompleteCurrentSequence()
@@ -227,6 +299,12 @@ public class UIManager : SystemObject
     {
         // ターン終了ボタンの設定
         turnUI.SetTurnEndButton(isOwnTurn);
+    }
+
+    // ターン終了
+    public void EndTurn()
+    {
+        cardDetailUI.EnableUI(false);
     }
 
     /// <summary>
@@ -410,7 +488,7 @@ public class UIManager : SystemObject
         CardObject cardObject = GetUnuseCardObject();
         // カードデータセット
         cardObject.SetCardData(drawCard);
-        cardObject.SetCardState(CardObject.CardState.HAND);
+        cardObject.SetCardState(CardState.HAND);
         drawCardObject = cardObject;
 
         bool isMine = playerID == (int)GameEnum.PlayerType.OWN;
@@ -621,7 +699,7 @@ public class UIManager : SystemObject
             CardObject cardObject = GetUnuseCardObject();
             // カードデータセット
             cardObject.SetCardData(drawCards[i]);
-            cardObject.SetCardState(CardObject.CardState.REDRAW);
+            cardObject.SetCardState(CardState.REDRAW);
         }
         redrawUI.StartRedraw(drawCards, ownDeckObject.transform);
 
@@ -635,6 +713,112 @@ public class UIManager : SystemObject
         ShowUI();
 
         return;
+    }
+
+    /// <summary>
+    /// カードとリーダーの選択
+    /// </summary>
+    public void SelectTarget(List<BaseComponent> targets)
+    {
+        SetUIState(UIState.SELECT);
+        // 他のUIの選択無効
+        // 手札選択か、盤面選択かで並べ方変更
+        // ターゲットオブジェクトを持ち上げ、選択可能にする
+
+        // オブジェクトを任意数クリックしたら、選択したコンポーネントを呼び出し元に返す
+        
+    }
+
+    public class TargetSelectResult
+    {
+        public bool result;
+        public List<BaseFieldObject> selected;
+    }
+    private UniTaskCompletionSource<TargetSelectResult> _selectTcs;
+
+    private Target _currentTarget;
+    private List<BaseFieldObject> _candidates;
+    private List<BaseFieldObject> _selected = new();
+
+    public UniTask<TargetSelectResult> SelectTargetAsync(
+    Target target,
+    List<BaseFieldObject> candidates)
+    {
+        // 二重選択防止
+        if (_selectTcs != null)
+            throw new InvalidOperationException("Target selection already running");
+
+        _currentTarget = target;
+        _candidates = candidates;
+        _selected.Clear();
+
+        _selectTcs = new UniTaskCompletionSource<TargetSelectResult>();
+
+        // 入力状態を変更
+        SetUIState(UIState.SELECT);
+
+        // 対象を選択可能にする
+        foreach (var card in _candidates)
+        {
+            card.EnableSelectable(true);
+            card.OnClick += OnCardClicked;
+        }
+
+        return _selectTcs.Task;
+    }
+
+    private void OnCardClicked(BaseFieldObject fieldObject)
+    {
+        if (_selectTcs == null) return;
+
+        // 候補にない場合は無視
+        if (!_candidates.Contains(fieldObject)) return;
+
+        // 既に選択されている場合はトグル
+        if (_selected.Contains(fieldObject))
+        {
+            _selected.Remove(fieldObject);
+            fieldObject.SetSelected(false);
+            return;
+        }
+        // 新規選択
+        _selected.Add(fieldObject);
+        fieldObject.SetSelected(true);
+
+        // 必要枚数選ばれたら完了
+        if (_selected.Count >= _currentTarget.count)
+        {
+            CompleteSelection(true);
+        }
+    }
+
+    private void CompleteSelection(bool isComplete)
+    {
+        Cleanup();
+        List<BaseFieldObject> selected = isComplete ? _selected : null;
+        _selectTcs.TrySetResult(new TargetSelectResult
+        {
+            result = isComplete,
+            selected = new List<BaseFieldObject>(selected)
+        });
+
+        _selectTcs = null;
+    }
+
+    private void Cleanup()
+    {
+        foreach (var card in _candidates)
+        {
+            card.EnableSelectable(false);
+            card.SetSelected(false);
+            card.OnClick -= OnCardClicked;
+        }
+
+        _currentTarget = null;
+        _candidates = null;
+        _selected.Clear();
+
+        SetUIState(UIState.DEFAULT);
     }
 
     public void OnGUI()

--- a/Assets/Scripts/System/MasterData/CardMasterUtility.cs
+++ b/Assets/Scripts/System/MasterData/CardMasterUtility.cs
@@ -61,7 +61,8 @@ public class CardMasterUtility
             cardMaster.Cost,
             cardMaster.Attack,
             cardMaster.Defence,
-            cardMaster.Token);
+            cardMaster.Token,
+            cardMaster.Trait);
         // テキストデータ取得
         cardData.SetText(CardTextMasterUtility.GetCardText(cardMaster.ID));
         return cardData;


### PR DESCRIPTION
カードの詳細UIのアクトと融合ボタンが正しいタイミングで表示、押せるように変更
カードにタイプを登録する機能の追加